### PR TITLE
docs(readme): add PyPI badges, install hint, and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 
 Quick Start
 -----------
-- Install (PyPI): `python -m pip install smart-srt-translator[openai]`
+- Install (PyPI): `python -m pip install "smart-srt-translator[openai]"` (zsh/PowerShell: Extras immer in Anführungszeichen setzen)
 - Create venv (choose one, depending on your setup):
   - Windows: `py -m venv .venv` or `python -m venv .venv`
   - macOS/Linux: `python3 -m venv .venv` (or `python -m venv .venv`)
@@ -24,7 +24,7 @@ Quick Start
     - PowerShell: `.venv\Scripts\Activate.ps1`
     - CMD: `.venv\Scripts\activate.bat`
     - bash/zsh: `source .venv/bin/activate`
-- Install (local): `python -m pip install -e .[openai]` (omit `[openai]` to skip OpenAI extra)
+- Install (local): `python -m pip install -e ".[openai]"` (zsh/PowerShell: Extras in Anführungszeichen, `[openai]` kann sonst als Glob interpretiert werden)
 - Translate (CLI):
   - Smart (default): `srt-translate translate Sample/firstdayinnewhospital.srt en de`
   - Provider is `openai` by default; mode `smart` by default.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 Smart SRT Translator
 ====================
 
+![PyPI](https://img.shields.io/pypi/v/smart-srt-translator)
+![Python Versions](https://img.shields.io/pypi/pyversions/smart-srt-translator)
+![License](https://img.shields.io/badge/license-MIT-blue.svg)
+
 A lightweight, extensible Python package for translating SRT subtitle files, with optional audio probe support and pluggable providers (OpenAI, etc.).
 
 Features
@@ -12,6 +16,7 @@ Features
 
 Quick Start
 -----------
+- Install (PyPI): `python -m pip install smart-srt-translator[openai]`
 - Create venv (choose one, depending on your setup):
   - Windows: `py -m venv .venv` or `python -m venv .venv`
   - macOS/Linux: `python3 -m venv .venv` (or `python -m venv .venv`)
@@ -115,3 +120,9 @@ Further Docs
 ------------
 - Parameter reference: see PARAMS.md for a concise overview of modes, flags, defaults, and recipes.
  - Readability guide: see READABILITY.md for DE presets and timing expansion tips.
+
+Links
+-----
+- PyPI: https://pypi.org/project/smart-srt-translator/
+- Source: https://github.com/ddumdi11/smart-srt-translator
+- Issues: https://github.com/ddumdi11/smart-srt-translator/issues

--- a/README.md
+++ b/README.md
@@ -126,3 +126,17 @@ Links
 - PyPI: https://pypi.org/project/smart-srt-translator/
 - Source: https://github.com/ddumdi11/smart-srt-translator
 - Issues: https://github.com/ddumdi11/smart-srt-translator/issues
+
+Easter Egg
+----------
+<details>
+<summary>A tiny poem from our CI burrow</summary>
+
+I thump my paws at version’s birth,
+A wheel rolls out, a sdist’s mirth.
+On release winds I softly fly,
+From Actions’ burrow to PyPI.
+Carrots cached, duplicates skipped—
+Ship it clean, neatly shipped!
+
+</details>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added PyPI, Python versions, and license badges to the README header.
  * Clarified Quick Start install commands: added PyPI install line, quoted extras, and local editable install guidance; recommended using python -m pip inside virtual environments (with platform note).
  * DE Quick Start: noted the CLI auto-loads a .env with OPENAI_API_KEY and optional OPENAI_MODEL.
  * Added Links section (PyPI, source, issues) and a short CI-themed Easter egg poem.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->